### PR TITLE
Linkss

### DIFF
--- a/draft-schinazi-masque-obfuscation.md
+++ b/draft-schinazi-masque-obfuscation.md
@@ -36,8 +36,8 @@ websites via easy to configure open-source software.
 This document is a straw-man proposal. It does not contain enough details to
 implement the protocol, and is currently intended to spark discussions on
 the approach it is taking. Discussion of this work is encouraged to happen on
-the MASQUE IETF mailing list <masque@ietf.org> or on the GitHub repository
-which contains the draft: <https://github.com/DavidSchinazi/masque-drafts>.
+the MASQUE IETF mailing list [](masque@ietf.org) or on the GitHub repository
+which contains the draft: [](https://github.com/DavidSchinazi/masque-drafts).
 
 
 --- middle
@@ -57,8 +57,8 @@ websites via easy to configure open-source software.
 This document is a straw-man proposal. It does not contain enough details to
 implement the protocol, and is currently intended to spark discussions on
 the approach it is taking. Discussion of this work is encouraged to happen on
-the MASQUE IETF mailing list <masque@ietf.org> or on the GitHub repository
-which contains the draft: <https://github.com/DavidSchinazi/masque-drafts>.
+the MASQUE IETF mailing list [](masque@ietf.org) or on the GitHub repository
+which contains the draft: [](https://github.com/DavidSchinazi/masque-drafts).
 
 MASQUE Obfuscation is built upon the MASQUE protocol
 {{!MASQUE=I-D.schinazi-masque-protocol}}. MASQUE Obfuscation leverages the efficient

--- a/draft-schinazi-masque-protocol.md
+++ b/draft-schinazi-masque-protocol.md
@@ -31,8 +31,8 @@ and subsequently make use of this functionality while concurrently processing
 HTTP/3 requests and responses.
 
 Discussion of this work is encouraged to happen on the MASQUE IETF mailing
-list <masque@ietf.org> or on the GitHub repository which contains the draft:
-<https://github.com/DavidSchinazi/masque-drafts>.
+list [](masque@ietf.org) or on the GitHub repository which contains the draft:
+[](https://github.com/DavidSchinazi/masque-drafts).
 
 
 --- middle
@@ -52,8 +52,8 @@ can subsequently leverage QUIC {{!QUIC=I-D.ietf-quic-transport}} features
 without using HTTP.
 
 Discussion of this work is encouraged to happen on the MASQUE IETF mailing
-list <masque@ietf.org> or on the GitHub repository which contains the draft:
-<https://github.com/DavidSchinazi/masque-drafts>.
+list [](masque@ietf.org) or on the GitHub repository which contains the draft:
+[](https://github.com/DavidSchinazi/masque-drafts).
 
 
 ## Conventions and Definitions {#conventions}


### PR DESCRIPTION
Did you know that you can put this sort of note in a file called `.note.xml` and it will be automatically included in all drafts?  You have to use XML, but you can also have the file automatically generated with `make -f lib/setup.mk .note.xml`.  That saves repetition, and it puts the right annotations on it so that it won't make it to publication by accident.